### PR TITLE
テーブル設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Things you may want to cover:
 |user_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :group_users
 - belongs_to :user
 - belongs_to :group
 
@@ -56,16 +55,17 @@ Things you may want to cover:
 |mail|sting|null: false, unique:true|
 
 ### Association
-- has_many :group,through :group_user
-- has_many :message
-- has_many :image
+- has_many :groups,through :group_users
+- has_many :messages
+- has_many :images
 
 ## groupテーブル
 
 |Column|Type|Option|
 |------|----|------|
-|group_name|string|index: true, null: false, foreign_key: true|
-|add_name|string|null: false, foreign_key: true
+|name|string|index: true, null: false,|
 
 ### Association
-- belongs_to :user, through : group_user
+- has_many :users, through : group_users
+- has_many :messages
+- has_many :group_users

--- a/README.md
+++ b/README.md
@@ -22,3 +22,50 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## messageテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|
+|image|string|
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group_users
+- belongs_to :user
+- belongs_to :group
+
+## userテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|index: true, null:false| 
+|mail|sting|null: false, unique:true|
+
+### Association
+- has_many :group,through :group_user
+- has_many :message
+- has_many :image
+
+## groupテーブル
+
+|Column|Type|Option|
+|------|----|------|
+|group_name|string|index: true, null: false, foreign_key: true|
+|add_name|string|null: false, foreign_key: true
+
+### Association
+- belongs_to :user, through : group_user


### PR DESCRIPTION
# What

アソシエーションのhas_manyの紐付けをすべて複数系にし、グループテーブルもhas_manyに変更して、外部キーを外しました

# Why
カリキュラムのアソシエーションの関係をもう一度見直し、それにあたってグループも必要と思われる関係を見直し、アソシエーションを増やしました。

